### PR TITLE
Filter-out unique course numbers before scraping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6598,6 +6598,11 @@
       "integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
       "dev": true
     },
+    "typescript-collections": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/typescript-collections/-/typescript-collections-1.3.3.tgz",
+      "integrity": "sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ=="
+    },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "js-joda": "^1.11.0",
     "request": "^2.88.2",
     "request-promise-native": "^1.0.9",
-    "scroll-into-view-if-needed": "^2.2.26"
+    "scroll-into-view-if-needed": "^2.2.26",
+    "typescript-collections": "^1.3.3"
   }
 }


### PR DESCRIPTION
Fixes #8. Filtering out unique courses makes scraping almost twice as fast now. Example:

```
scraped 1427 course numbers in total (removed 1401 duplicates)
```